### PR TITLE
Set version from VS Code workspace JSON file

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The extension will be activated automatically when it's installed.
 ### Smart Autocomplete
 
 Intelligent suggestions for Bootstrap class names.
-Enter a class name and the extension will suggest matching CSS classes, if not than try `ctrl + space` to trigger the autocomplete.
+Enter a class name and the extension will suggest matching CSS classes, if not then try `ctrl + space` to trigger the autocomplete.
 
 <img src="/assets/images/autocomplete.png"/>
 

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -26,7 +26,6 @@ const showMainMenu = async (statusBarItem: vscode.StatusBarItem) => {
     },
     {
       label: '$(sparkle) From local files for offline use',
-      description: 'coming soon',
     },
     {
       label: '',
@@ -58,8 +57,25 @@ const showMainMenu = async (statusBarItem: vscode.StatusBarItem) => {
       case '$(versions) Select Bootstrap version':
         showBootstrapVersionMenu(statusBarItem);
         break;
+      case '$(sparkle) From local files for offline use':
+        const localSetVersion = checkSetting('bootstrap-intelliSense.version');
+        if (localSetVersion) {
+          bootstrapVersion = localSetVersion;
+          bootstrapVersion = Number(localSetVersion.split(' ').pop());
+          setExtensionActive(statusBarItem);
+          vscode.window.showInformationMessage(`Bootstrap version set to v${bootstrapVersion}`);
+        } else {
+          vscode.window.showInformationMessage('No local version of Bootstrap found in Workspace settings.json');
+        }
+        break;
     }
   }
+};
+
+const checkSetting = (settingKey: string): any => {
+  const configuration = vscode.workspace.getConfiguration();
+  const settingValue = configuration.get(settingKey);
+  return settingValue;
 };
 
 const setExtensionActive = (statusBarItem: vscode.StatusBarItem) => {


### PR DESCRIPTION
My first TypeScript code as well as my first time looking into VS Code extensions [I am not a coder]. Please review my intent as this code is probably not production-ready.

For my use case, I maintain a collection of documentation written in a mix of Markdown and HTML based on a bootstrap-enabled theme. However, the assets of the ultimate build are hosted outside my local repo and therefore not available. Using this extension is wonderful, however I have to manually select my bootstrap version each time I open VS Code. My PR creates a method for storing my project's bootstrap version in a local file (VS Code workspace settings JSON) which can be enabled by selecting the presently unused main menu item. If I were to develop this further, I would maybe create an extension setting to enable an auto-check for this value upon extension initialization, and another setting to select from a list of bootstrap versions - which would become the saved value.

Thank you for this extension!