### PR TITLE
Added .gjs and .gts support for Ember.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v2.0.3 2025-02-13
+
+- Added .gjs and .gts support
+
 ## v2.0.2 2024-12-15
 
 - Added .lava support

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bootstrap-intellisense",
-  "version": "2.0.0",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bootstrap-intellisense",
-      "version": "2.0.0",
+      "version": "2.0.3",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bootstrap-intellisense",
   "displayName": "Bootstrap IntelliSense",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Enhance Bootstrap development with CSS class autocompletion for efficient coding in Visual Studio Code.",
   "categories": [
     "Linters",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -46,6 +46,8 @@ const languageSupport = [
   'jinja-html',
   'jar',
   'lava',
+  'glimmer-js',
+  'glimmer-ts',
 ];
 
 const provideCompletionItems = (


### PR DESCRIPTION
The JavaScript framework Ember.js previously used .hbs (handlebars) files for its templating.

In new versions, they now support their own file format called .gjs and .gts. You can read about it [here](https://guides.emberjs.com/release/components/template-tag-format/).

The company I work at is using Bootstrap for their new design system within Ember.js. It would be nice for this extension to work within this new file format.

I previously already cloned the repo down and built a version with these changes locally. It made the developer experience much nicer. It would be nice to see it supported within the official extension.

Let me know what you think!