### PR TITLE
Re-added legacy Bootstrap 5 versions to selection menu

### DIFF
--- a/src/features/menu/menu.ts
+++ b/src/features/menu/menu.ts
@@ -386,6 +386,8 @@ export class Menu {
       { label: '$(add) Bootstrap 5.2.2' },
       { label: '$(add) Bootstrap 5.2.1' },
       { label: '$(add) Bootstrap 5.2.0' },
+      { label: '$(add) Bootstrap 5.1.3' },
+      { label: '$(add) Bootstrap 5.0.2' },
     ];
 
     const versionSelection = await vscode.window.showQuickPick(version5Options, {


### PR DESCRIPTION
Re-added these two versions to cover all minor versions of Bootstrap 5 (only added latest patch versions - this changes is only for compatibility sake anyway).

Checked `jsDelivr` to make sure these versions are available there.

Fixes #41 